### PR TITLE
The Error functions in epanettools and pdd_class_wrapper don't work has intended

### DIFF
--- a/src/epanettools/epanettools.py
+++ b/src/epanettools/epanettools.py
@@ -7,6 +7,7 @@ import tempfile
 
 from . import adf
 from . import tools
+from .epanet2 import ENgeterror
 from .pdd_class_wrapper import pdd_wrapper_class
 
 """" Never use ENOpen ENclose without keeping tab. -- always use _close and _open methods instead.
@@ -20,7 +21,7 @@ def Error(e):
     if(e):
         try:
             s = "Epanet Error: %d : %s" % (
-                e, pdd_wrapper_class.ENgeterror(e, 500)[1])
+                e, ENgeterror(e, 500)[1])
         except:
             s= "Epanet Error: %d " % (e)
         raise Exception(s)

--- a/src/epanettools/pdd_class_wrapper.py
+++ b/src/epanettools/pdd_class_wrapper.py
@@ -4,7 +4,7 @@ from . import pdd as pd
 def Error(e):
     if(e):
         s = "Epanet Error: %d : %s" % (
-            e, pdd_wrapper_class.ENgeterror(e, 500)[1])
+            e, pd.ENgeterror(e, 500)[1])
         raise Exception(s)
 
 

--- a/tests/test_EPANetPDD.py
+++ b/tests/test_EPANetPDD.py
@@ -121,6 +121,13 @@ class Test1(unittest.TestCase):
         mod2()
         mod3()
 
+    def test_ppd_wrapper_error_func(self):
+        from epanettools.pdd_class_wrapper import Error
+        with self.assertRaises(Exception) as e:
+            Error(202)
+        self.assertEqual(e.exception.args[0],
+                         'Epanet Error: 202 : Input Error 202: function call  contains illegal numeric value.')
+
 
 def clt(fn, tc):
     tc.setUp()

--- a/tests/test_epanettools.py
+++ b/tests/test_epanettools.py
@@ -16,6 +16,12 @@ class Test1(unittest.TestCase):
             print((e, et.ENgeterror(e, 25)))
             exit(5)
 
+    def test_error_func(self):
+        from epanettools.epanettools import Error
+        with self.assertRaises(Exception) as e:
+            Error(202)
+        self.assertEqual(e.exception.args[0], "Epanet Error: 202 : Input Error 202: function call  contains illegal numeric value.")
+    
     def test_basic(self):
         import os
         from epanettools import epanet2 as et


### PR DESCRIPTION
Both these functions use the` pdd_wrapper_class.ENgeterror()` function to get the error message, but `pdd_wrapper_class` is a type so we get an `AttributeError` that is silenced because the `Error` function is supposed to always raise an `Exception` and in the case of the function in epanettools there is a try-except block that catches this exception and raises another one.

In here I have 2 new tests that catch these bugs and a possible fix.